### PR TITLE
Upgrade of Lodash from 4.17.15 to 4.17.20

### DIFF
--- a/jsonParser/old_parser/package-lock.json
+++ b/jsonParser/old_parser/package-lock.json
@@ -3125,7 +3125,7 @@
       "integrity": "sha512-Z/m+OFOe13Nn2SHQNSINZ6Mh2b8t2bK3whL3L6b5Av1wqDvotYvpMg1Zi8aEPV37jF0jG0yQ83c8XuuNbIsn6Q==",
       "requires": {
         "async": "^3.2.0",
-        "lodash": "^4.17.13",
+        "lodash": "^4.17.20",
         "optimist": "^0.6.1",
         "xmldom": "^0.3.0"
       },
@@ -3135,7 +3135,7 @@
           "bundled": true
         },
         "lodash": {
-          "version": "4.17.15",
+          "version": "4.17.20",
           "bundled": true
         },
         "minimist": {


### PR DESCRIPTION
Upgrade of lodash from 4.17.15 to 4.17.20 bcz lodash of older version have a vulnerability of Prototype pollution.
### PoC
```
const _ = require('lodash');
_.zipObjectDeep(['__proto__.z'],[123])
console.log(z) // 123
```
### Types of Attacks 

- Client Side (DoS, Remote Code Execution and Property Injection)